### PR TITLE
fix(rides): permettre plus de 6 groupes par ride

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,6 +15,9 @@ spring.mvc.pathmatch.matching-strategy=ant_path_matcher
 
 spring.servlet.multipart.max-file-size=10MB
 spring.servlet.multipart.enabled=true
+# Tomcat 10.1.42+ counts every multipart field as a "part" (default limit : 50).
+# Ride/trip/template forms send ~6 fields per group, so 7 groups was enough to blow the limit.
+server.tomcat.max-part-count=1000
 
 server.servlet.session.timeout=86400s
 server.servlet.session.cookie.max-age=86400s


### PR DESCRIPTION
## Symptôme

Depuis fin juillet, créer ou modifier un ride avec **plus de 6 groupes** provoque une erreur et renvoie sur un formulaire vide : toute la saisie est perdue. Les équipes contournent en créant deux rides séparés.

## Cause

Tomcat 10.1.42 a introduit la limite `maxPartCount`, que Spring Boot fixe par défaut à **50** (`server.tomcat.max-part-count`).

Le formulaire de ride est en `multipart/form-data` (à cause de l'image associée), donc **chaque champ compte comme un « part »** :

- 12 champs fixes : `templateId`, `publishedAtDate`, `publishedAtTime`, `listedInFeed`, `title`, `date`, `type`, `permalink`, `startPlaceId`, `endPlaceId`, `file`, `description`
- **6 champs par groupe** : `id`, `name`, `meetingTime`, `averageSpeed`, `mapName`, `mapId`

Soit :

| Groupes | Parts | Résultat |
|---|---|---|
| 6 | 12 + 36 = **48** | OK |
| 7 | 12 + 42 = **54** | rejeté |

L'exception est ensuite avalée par le `catch` de `AdminTeamRideController` (ligne 216), qui redirige vers `/admin/rides/new` — d'où la perte complète de la saisie et l'absence de trace dans les logs.

## Datation de la régression

- En production, `tomcat-embed-core` est passé de **10.1.41 à 10.1.44** le 2026-07-24 (Spring Boot 3.5.0 → 3.5.5).
- Le dernier ride à plus de 6 groupes en base date du **2026-07-22** ; aucun depuis.

## Correctif

`server.tomcat.max-part-count=1000`, soit ~165 groupes. Couvre aussi les formulaires de trip (étapes) et de template de ride, construits sur le même modèle.

## Vérification

Créer un ride avec 8 groupes depuis l'admin et l'enregistrer : le ride est créé avec ses 8 groupes.

## Pistes de suivi (hors périmètre de cette MR)

- `AdminTeamRideController` avale l'exception sans la logger — d'où l'absence totale de trace en prod.
- En cas d'erreur, le redirect perd la saisie ; réafficher le formulaire rempli serait plus robuste.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EASmPgYorQhtvcYRnGe7Bo