### PR TITLE
fix(rides): allow more than 6 groups per ride (#388)

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,6 +15,9 @@ spring.mvc.pathmatch.matching-strategy=ant_path_matcher
 
 spring.servlet.multipart.max-file-size=10MB
 spring.servlet.multipart.enabled=true
+# Tomcat 10.1.42+ counts every multipart field as a "part" (default limit : 50).
+# Ride/trip/template forms send ~6 fields per group, so 7 groups was enough to blow the limit.
+server.tomcat.max-part-count=1000
 
 server.servlet.session.timeout=86400s
 server.servlet.session.cookie.max-age=86400s


### PR DESCRIPTION
Tomcat 10.1.42 introduced a maxPartCount limit, defaulted to 50 by Spring Boot. Since the ride form is multipart/form-data, every field counts as a part: 12 fixed fields + 6 per group. Six groups meant 48 parts (fine), seven meant 54 and the request was rejected — the resulting redirect sent the user back to an empty form, losing the whole ride.

The regression appeared when production moved from tomcat-embed-core 10.1.41 to 10.1.44 on 2026-07-24; the last ride with more than 6 groups dates from 2026-07-22.

Raise the limit to 1000 parts (~165 groups), which also covers the trip and ride template forms built the same way.


Claude-Session: https://claude.ai/code/session_01EASmPgYorQhtvcYRnGe7Bo